### PR TITLE
Move postgres password into secret

### DIFF
--- a/charts/kellnr/templates/config.yaml
+++ b/charts/kellnr/templates/config.yaml
@@ -26,5 +26,4 @@ data:
   KELLNR_POSTGRES__ADDRESS: {{ .Values.kellnr.postgres.address | quote }}
   KELLNR_POSTGRES__PORT: {{ .Values.kellnr.postgres.port | quote }}
   KELLNR_POSTGRES__USER: {{ .Values.kellnr.postgres.user | quote }} 
-  KELLNR_POSTGRES__PWD: {{ .Values.kellnr.postgres.pwd | quote }}
   

--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
           - name: RUST_BACKTRACE
             value: "1"
           {{- end }}
+          {{- if .Values.kellnr.postgres.enabled }}
+          - name: KELLNR_POSTGRES__PWD
+            valueFrom:
+              secretKeyRef: {{ toYaml .Values.kellnr.postgres.pwdSecretRef | nindent 16 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ .Values.configMap.name | quote }}

--- a/charts/kellnr/templates/secret.yml
+++ b/charts/kellnr/templates/secret.yml
@@ -1,0 +1,8 @@
+{{ if and .Values.kellnr.postgres.enabled (not (empty .Values.kellnr.postgres.pwd)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.kellnr.postgres.pwdSecretRef.name }}
+stringData:
+  {{ .Values.kellnr.postgres.pwdSecretRef.key }}: "{{ .Values.kellnr.postgres.pwd }}"
+{{- end }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -86,6 +86,9 @@ kellnr:
     db: "kellnr"
     user: ""
     pwd: ""
+    pwdSecretRef:
+      name: kellnr-postgres-user
+      key: password
 
 service:
   api:


### PR DESCRIPTION
Moves the postgres password out of the Configmap, and into a Secret. Also, if `kellnr.postgres.pwd` is left empty, allows for an existing Secret to be used with `kellnr.postgres.pwdSecretRef`.