### PR TITLE
run rootless by default

### DIFF
--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           configMap:
             name: {{ .Values.importCert.configMapName | quote }}
         {{- end }}
+        - name: certs
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
      
         {{- if .Values.dns.enabled }}
       dnsPolicy: {{ .Values.dns.dnsPolicy | quote }}
@@ -92,6 +96,10 @@ spec:
               mountPath: "{{ .Values.kellnr.registry.dataDir }}/cert"
               readOnly: true
             {{- end }}
+            - mountPath: /etc/ssl/certs
+              name: certs
+            - mountPath: /tmp
+              name: tmp
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -36,13 +36,12 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
 
 deployment:
   volumes:


### PR DESCRIPTION
This chart runs the container as root, which introduces safety vulnerabilities.

Ideally, I belive this chart should run followintg the [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)

Because of the script to update the certificates, this chart needs a few tweaks. With the changes in this PR I'm able to run the container in a much safer way as it's rootless and can't edit root filesystem.