### PR TITLE
fix: misplaced `{{ end }}` tag for "volumes" and "volumeMounts"

### DIFF
--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -85,7 +85,6 @@ spec:
               protocol: TCP
           {{- if or .Values.pvc.enabled .Values.importCert.enabled }}
           volumeMounts:
-          {{- end }}
             {{- if .Values.pvc.enabled }}
             - mountPath: {{ .Values.kellnr.registry.dataDir | quote }}
               name: {{ .Values.deployment.volumes.name }}
@@ -100,6 +99,7 @@ spec:
               name: certs
             - mountPath: /tmp
               name: tmp
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -29,7 +29,6 @@ spec:
     spec:
       {{- if or .Values.pvc.enabled .Values.importCert.enabled }}
       volumes:
-      {{- end }}
         {{- if .Values.pvc.enabled }}
         - name: {{ .Values.deployment.volumes.name }}
           persistentVolumeClaim:
@@ -44,6 +43,7 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+      {{- end }}
       {{- if .Values.dns.enabled }}
       dnsPolicy: {{ .Values.dns.dnsPolicy | quote }}
       dnsConfig:


### PR DESCRIPTION
Solves the error:
```sh
Error: INSTALLATION FAILED: YAML parse error on kellnr/templates/deployment.yaml: error converting YAML to JSON: yaml: line 31: did not find expected key
```

I have tested the changes:
```sh
helm lint . --with-subcharts         
==> Linting .
[INFO] Chart.yaml: icon is recommended

==> Linting charts/kellnr-3.2.7.tgz
[INFO] Chart.yaml: icon is recommended

2 chart(s) linted, 0 chart(s) failed
```

In my setup, kellnr is a chart dependency - should not have an impact.