### PR TITLE
Remove `securityContext.readOnlyRootFilesystem` and modify `origin.hostname`

### DIFF
--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -73,7 +73,7 @@ kellnr:
     ip: "0.0.0.0"
     port: 80
   origin:
-    hostname: "127.0.0.1"
+    hostname: "localhost"
     port: 80
     protocol: "http"
   postgres:

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -39,7 +39,6 @@ securityContext:
   capabilities:
     drop:
       - ALL
-  readOnlyRootFilesystem: true
 
 deployment:
   volumes:


### PR DESCRIPTION
The presence of `securityContext.readOnlyRootFilesystem: true` prevents the container from starting:
- the entrypoint of the kellnr docker image runs `update-ca-certificates`
- `update-ca-certificates` calls `mktemp`, which tries to write to `/tmp`
- since the root filesystem is readonly, `update-ca-certificates` fails and the container does not start

The value `origin.hostname: "127.0.0.1"` is semantically correct, but invalid:
```sh
Ingress.extensions "kellnr" is invalid: spec.rules[0].host: Invalid value: "127.0.0.1": must be a DNS name, not an IP address
```