### PR TITLE
Enable the use of an existing PersistentVolumeClaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ helm install kellnr kellnr/kellnr --set kellnr.origin.hostname="kellnr.example.c
 For a persistent _Kellnr_ instance, a _PersistentVolumeClaim_ (PVC) is needed. The helm chart can create a _PersistentVolumeClaim_ and _PersistentVolume_ (PV), if you don't have one already.
 
 ```bash
+# Use an existing PersistentStorageClaim.
+helm install kellnr kellnr/kellnr \
+    --set pvc.enabled=true --set pvc.useExistingClaim=true \
+    --set pvc.name="storage_name"
+```
+
+```bash
 # Use an existing PersistentStorage (storage_name) to get a PersistentStorageClaim.
 # The storage class can be overwritten with "pvc.storageClassName" and defaults to "manual".
 helm install kellnr kellnr/kellnr \
@@ -60,7 +67,7 @@ All settings can be set with the `--set name=value` flag on `helm install`. Some
 
 ### Kellnr
 
-Check the [documentation](https://kellnr.io/documentation) and the [values.yaml](./charts/kellnr/values.yaml) for possible configuration values. 
+Check the [documentation](https://kellnr.io/documentation) and the [values.yaml](./charts/kellnr/values.yaml) for possible configuration values.
 
 ### Service
 

--- a/charts/kellnr/Chart.yaml
+++ b/charts/kellnr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.5.0
+version: 3.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -30,9 +30,9 @@ spec:
       {{- if or .Values.pvc.enabled .Values.importCert.enabled }}
       volumes:
         {{- if .Values.pvc.enabled }}
-        - name: {{ .Values.deployment.volumes.name }}
+        - name: kellnr-storage
           persistentVolumeClaim:
-            claimName: {{ .Values.deployment.volumes.persistentVolumeClaim }}
+            claimName: {{ .Values.pvc.name }}
         {{- end }}
         {{- if .Values.importCert.enabled }}
         - name: {{ .Values.importCert.volumeName | quote }}
@@ -87,7 +87,7 @@ spec:
           volumeMounts:
             {{- if .Values.pvc.enabled }}
             - mountPath: {{ .Values.kellnr.registry.dataDir | quote }}
-              name: {{ .Values.deployment.volumes.name }}
+              name: kellnr-storage
               readOnly: false
             {{- end }}
             {{- if .Values.importCert.enabled }}

--- a/charts/kellnr/templates/pvc.yaml
+++ b/charts/kellnr/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pvc.useExistingClaim -}}
 {{- if .Values.pvc.enabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -10,4 +11,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.pvc.storage }}
+{{- end }}
 {{- end }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -40,11 +40,6 @@ securityContext:
     drop:
       - ALL
 
-deployment:
-  volumes:
-    name: "kellnr-storage"
-    persistentVolumeClaim: "kellnr"
-
 configMap:
   name: "kellnr-config"
 
@@ -109,6 +104,7 @@ pv:
 
 pvc:
   enabled: false
+  useExistingClaim: false
   name: "kellnr"
   storageClassName: "manual"
   storage: 5Gi


### PR DESCRIPTION
Cluster admins may create PersistentVolumes that are not backed by node storage (e.g. NFS). This change allows the use of an existing PersistentVolumeClaim to take advantage of such topologies.