### PR TITLE
feat: setting  `origin.protocol` automatically sets `port` if `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,26 +66,26 @@ Check the [documentation](https://kellnr.io/documentation) and the [values.yaml]
 
 Settings to configure the web-ui/API endpoint service and the crate index service.
 
-| Setting                | Required | Description                                                   | Default   |
-| ---------------------- | -------- | ------------------------------------------------------------- | --------- |
-| service.api.type       | No       | Type of the service that exports the API and web-ui endpoint. | ClusterIP |
-| service.api.port       | No       | Port of the service that exports the API and web-ui endpoint. | 80        |
+| Setting          | Required | Description                                                   | Default   |
+|------------------|----------|---------------------------------------------------------------|-----------|
+| service.api.type | No       | Type of the service that exports the API and web-ui endpoint. | ClusterIP |
+| service.api.port | No       | Port of the service that exports the API and web-ui endpoint. | 80        |
 
 ### Ingress
 
 Setting to configure the ingress route for the web-ui and API.
 
-| Setting             | Required | Description                                      | Default |
-| ------------------- | -------- | ------------------------------------------------ | ------- |
-| ingress.enabled     | No       | Enable an Kubernetes ingress route for _Kellnr_. | true    |
-| ingress.className   | No       | Set an ingress className.                        | ""      |
-| ingress.annotations | No       | Set ingress annotations.                         | {}      |
-| ingress.tls.secretName | No   | Set the secret name for a TLS certificate         | kellnr-cert-secret |
+| Setting                | Required | Description                                      | Default            |
+|------------------------|----------|--------------------------------------------------|--------------------|
+| ingress.enabled        | No       | Enable an Kubernetes ingress route for _Kellnr_. | true               |
+| ingress.className      | No       | Set an ingress className.                        | ""                 |
+| ingress.annotations    | No       | Set ingress annotations.                         | {}                 |
+| ingress.tls.secretName | No       | Set the secret name for a TLS certificate        | kellnr-cert-secret |
 
 ### TLS Certificate
 
 Settings to configure a TLS certificate with cert-manager. **Important** If you use _Kellnr_ with TLS,
-make sure to set `kellnr.apiProtocol` to `https`.
+make sure to set `kellnr.origin.protocol` to `https`.
 
 | Setting | Required | Description | Default |
 | ---------------------- | -------- | ------------------------------------------------------------- | --------- |
@@ -134,12 +134,12 @@ You can set DNS servers for _Kellnr_ which should be used instead of the default
 
 > Kellnr needs to be able to resolve it's own domain name, to be able to generate Rustdocs automatically.
 
-| Setting | Required | Description | Default |
-| ---------------------- | -------- | ------------------------------------------------------------- | --------- |
-| dns.enabled | No | Enable an additional _dnsPolicy_ | false |
-| dns.dnsPolicy | No | Set the _dnsPolicy_ | "None" |
-| dns.dnsConfig.nameservers | No | List of nameservers to use. | - "" |
-| dns.dnsConfig.searches | No | List of searches to use. | - "" |
+| Setting                   | Required | Description                      | Default |
+|---------------------------|----------|----------------------------------|---------|
+| dns.enabled               | No       | Enable an additional _dnsPolicy_ | false   |
+| dns.dnsPolicy             | No       | Set the _dnsPolicy_              | "None"  |
+| dns.dnsConfig.nameservers | No       | List of nameservers to use.      | - ""    |
+| dns.dnsConfig.searches    | No       | List of searches to use.         | - ""    |
 
 ### Persistence
 

--- a/charts/kellnr/templates/NOTES.txt
+++ b/charts/kellnr/templates/NOTES.txt
@@ -3,6 +3,6 @@ Thank you for installing {{ .Chart.Name }}.
 Installed Chart version: {{ .Chart.Version }}
 Installed Kellnr version: {{ .Chart.AppVersion }}
 
-  - Web UI & API Endpoint: "{{ .Values.kellnr.origin.protocol }}://{{ .Values.kellnr.origin.hostname }}:{{ .Values.kellnr.origin.port }}"
+  - Web UI & API Endpoint: "{{ .Values.kellnr.origin.protocol }}://{{ .Values.kellnr.origin.hostname }}:{{ include "kellnr.serviceOriginPort" . }}"
 
 For documentation on how to configure Cargo to use Kellnr, see: https://kellnr.io/documentation

--- a/charts/kellnr/templates/_helpers.tpl
+++ b/charts/kellnr/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Decide the proxy port number to use if set to auto
+*/}}
+{{- define "kellnr.serviceOriginPort" -}}
+{{- if eq .Values.kellnr.origin.protocol "https" }}
+{{- default 443 .Values.kellnr.origin.port }}
+{{- else }}
+{{- default 80 .Values.kellnr.origin.port }}
+{{- end }}
+{{- end }}

--- a/charts/kellnr/templates/config.yaml
+++ b/charts/kellnr/templates/config.yaml
@@ -20,7 +20,7 @@ data:
   KELLNR_LOCAL__IP: {{ .Values.kellnr.local.ip | quote }}
   KELLNR_LOCAL__PORT: {{ .Values.kellnr.local.port | quote }}
   KELLNR_ORIGIN__HOSTNAME: {{ required "A valid hostname, where Kellnr will be reachable is required." .Values.kellnr.origin.hostname | quote }}
-  KELLNR_ORIGIN__PORT: {{ .Values.kellnr.origin.port | quote }}
+  KELLNR_ORIGIN__PORT: {{ include "kellnr.serviceOriginPort" . | quote }}
   KELLNR_ORIGIN__PROTOCOL: {{ .Values.kellnr.origin.protocol | quote }}
   KELLNR_POSTGRESQL__ENABLED: {{ .Values.kellnr.postgres.enabled | quote }}
   KELLNR_POSTGRESQL__ADDRESS: {{ .Values.kellnr.postgres.address | quote }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -73,7 +73,8 @@ kellnr:
     port: 80
   origin:
     hostname: "localhost"
-    port: 80
+    # Can be a number, or null (~) to automatically set to 443 if protocol is https, otherwise 80
+    port: null
     protocol: "http"
   postgres:
     enabled: false


### PR DESCRIPTION
* fixes incorrect README info, and format spaces for a few tables (i was looking for the `origin` table, but its not there)
* sets the `origin.port` value to `null` by default
* if `null` and `origin.protocol` is set to `https`, it becomes 443 otherwise it becomes 80
* this should not affect existing users who set the port value explicitly