### PR TITLE
feat: automatically update on config changes

### DIFF
--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -20,8 +20,10 @@ spec:
       {{- include "kellnr.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- /* This annotation is used to trigger a rolling update when the config changes */}}
+        configHash: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Add auto-computed annotation to trigger the rolling update whenever any configuration value is changed. This is a common source of issues -- configuration is modified, but the pod is not restarted.