### PR TITLE
fix: use `service.api.port` for `KELLNR_LOCAL__PORT`

### DIFF
--- a/charts/kellnr/templates/config.yaml
+++ b/charts/kellnr/templates/config.yaml
@@ -18,7 +18,7 @@ data:
   KELLNR_LOG__FORMAT: {{ .Values.kellnr.log.format | quote }}
   KELLNR_LOG__LEVEL_WEB_SERVER: {{ .Values.kellnr.log.levelWebServer | quote }}
   KELLNR_LOCAL__IP: {{ .Values.kellnr.local.ip | quote }}
-  KELLNR_LOCAL__PORT: {{ .Values.kellnr.local.port | quote }}
+  KELLNR_LOCAL__PORT: {{ .Values.service.api.port | quote }}
   KELLNR_ORIGIN__HOSTNAME: {{ required "A valid hostname, where Kellnr will be reachable is required." .Values.kellnr.origin.hostname | quote }}
   KELLNR_ORIGIN__PORT: {{ .Values.kellnr.origin.port | quote }}
   KELLNR_ORIGIN__PROTOCOL: {{ .Values.kellnr.origin.protocol | quote }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -70,7 +70,6 @@ kellnr:
     levelWebServer: "warn"
   local:
     ip: "0.0.0.0"
-    port: 80
   origin:
     hostname: "localhost"
     port: 80


### PR DESCRIPTION
Remove `kellnr.local.port` value - I can't think when it would make sense to have this value different from `service.api.port` - moreover, it wouldn't even work unless there is some additional port mapping done at the pod level (not even sure if that's allowed).  Now all templates use `service.api.port`.

Fixes #12