### PR TITLE
feat: use named ports

### DIFF
--- a/charts/kellnr/templates/ingress.yaml
+++ b/charts/kellnr/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kellnr.fullname" . -}}
-{{- $svcPort := .Values.service.api.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -45,9 +44,9 @@ spec:
           service:
             name: {{ $fullName }}
             port:
-              number: {{ $svcPort }}
+              name: kellnr-api
           {{- else }}
           serviceName: {{ $fullName }}
-          servicePort: {{ $svcPort }}
+          servicePort: kellnr-api
           {{- end }}
 {{- end }}

--- a/charts/kellnr/templates/service.yaml
+++ b/charts/kellnr/templates/service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
     - name: kellnr-api
       port: {{ .Values.service.api.port }}
+      targetPort: kellnr-api
       protocol: TCP
   selector:
     {{- include "kellnr.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Using named ports simplifies port management a bit, tying ingress-service-pod port mapping with a name rather than a number.