### PR TITLE
Add httpRoute

### DIFF
--- a/charts/kellnr/Chart.yaml
+++ b/charts/kellnr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.1
+version: 4.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kellnr/templates/httproute.yaml
+++ b/charts/kellnr/templates/httproute.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "kellnr.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "kellnr.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+  hostnames:
+    - {{ .Values.kellnr.origin.hostname | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.httproute.pathType }}
+            value: {{ .Values.httproute.path }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.service.api.port }}
+      {{- with .Values.httproute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -122,6 +122,26 @@ ingress:
   tls:
     secretName: "kellnr-cert-secret"
 
+httproute:
+  enabled: false
+  annotations: {}
+  # Reference to the Gateway(s) that this HTTPRoute should attach to
+  parentRefs:
+    - name: ""
+      namespace: ""
+  # Override hostnames (defaults to kellnr.origin.hostname if not set)
+  hostnames: []
+  path: "/"
+  pathType: "PathPrefix"
+  # Optional: filters for request/response modification
+  filters: []
+  # Example filters:
+  # - type: RequestHeaderModifier
+  #   requestHeaderModifier:
+  #     add:
+  #       - name: X-Custom-Header
+  #         value: custom-value
+
 certificate:
   enabled: false
   secretName: "kellnr-cert-secret"


### PR DESCRIPTION
This PR adds support for HTTPRoutes required for the Gateway API. Tested in my own cluster, it may not be perfect, but it exposes enough that you can automatically deploy access to the service.