### PR TITLE
updating to only include certain config conditionally

### DIFF
--- a/charts/kellnr/templates/config.yaml
+++ b/charts/kellnr/templates/config.yaml
@@ -11,7 +11,9 @@ data:
   KELLNR_REGISTRY__MAX_CRATE_SIZE: {{ .Values.kellnr.registry.maxCrateSize | quote }}
   KELLNR_REGISTRY__MAX_DB_CONNECTIONS: {{ .Values.kellnr.registry.maxDbConnections | quote }}
   KELLNR_REGISTRY__AUTH_REQUIRED: {{ .Values.kellnr.registry.authRequired | quote }}
+{{- if .Values.kellnr.registry.requiredCrateFields }}
   KELLNR_REGISTRY__REQUIRED_CRATE_FIELDS: {{ .Values.kellnr.registry.requiredCrateFields | quote }}
+{{- end }}
   KELLNR_REGISTRY__NEW_CRATES_RESTRICTED: {{ .Values.kellnr.registry.newCratesRestricted | quote }}
   KELLNR_DOCS__ENABLED: {{ .Values.kellnr.docs.enabled | quote }}
   KELLNR_DOCS__MAX_SIZE: {{ .Values.kellnr.docs.maxSize | quote }}
@@ -32,8 +34,12 @@ data:
   KELLNR_POSTGRESQL__USER: {{ .Values.kellnr.postgres.user | quote }}
   KELLNR_POSTGRESQL__DB: {{ .Values.kellnr.postgres.db | quote }}
   KELLNR_S3__ENABLED: {{ .Values.kellnr.s3.enabled | quote }}
+{{- if .Values.kellnr.s3.accessKey }}
   KELLNR_S3__ACCESS_KEY: {{ .Values.kellnr.s3.accessKey | quote }}
+{{- end }}
+{{- if .Values.kellnr.s3.secretKey }}
   KELLNR_S3__SECRET_KEY: {{ .Values.kellnr.s3.secretKey | quote }}
+{{- end }}
   KELLNR_S3__REGION: {{ .Values.kellnr.s3.region | quote }}
   KELLNR_S3__ENDPOINT: {{ .Values.kellnr.s3.endpoint | quote }}
   KELLNR_S3__ALLOW_HTTP: {{ .Values.kellnr.s3.allowHttp | quote }}


### PR DESCRIPTION
When using S3 via service account, certain fields should be omitted from this chart. If these are not included in the values.yaml, this will exclude these from the final manifests.