### PR TITLE
fix release charts to only release form main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
       - main
 jobs:
   release:
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'kellnr'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
There's a minor issue with the current gh actions workflow. It attempt to generate a new release of these charts from any branch, even temporary feature branches looking to merge (like this one). This PR fixes that will by gating the release block to run only with the main branch.