### PR TITLE
Add the target type to the hpa manifest

### DIFF
--- a/charts/kellnr/templates/hpa.yaml
+++ b/charts/kellnr/templates/hpa.yaml
@@ -18,6 +18,7 @@ spec:
       resource:
         name: cpu
         target:
+          type: Utilization
           averageUtilization: {{ .Values.autoscaling.target.CPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
@@ -25,6 +26,7 @@ spec:
       resource:
         name: memory
         target:
+          type: Utilization
           averageUtilization: {{ .Values.autoscaling.target.memoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Found this when trying to deploy and the hpa failed to create. Threw an error about resource.target.type is missing.