### PR TITLE
Fix env variable and allow additional config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides a [Helm](https://helm.sh/) Chart for [Kellnr](https://k
 
 ## Installation
 
-Add the _Kellr_ helm repository which contains _Kellnr_:
+Add the _Kellnr_ helm repository which contains _Kellnr_:
 
 ```bash
 # Add  repository

--- a/charts/kellnr/Chart.yaml
+++ b/charts/kellnr/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.1
+version: 6.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
           {{- if and .Values.docBuilder.enabled .Values.docBuilder.tokenSecretRef.name }}
           - name: RUSTUP_TOOLCHAIN
             value: {{ .Values.docBuilder.rustupToolchain | quote }}
-          - name: CARGO_REGISTRIES_{{ .Values.docBuilder.registryName | upper }}_TOKEN
+          - name: CARGO_REGISTRIES_{{ .Values.docBuilder.registryName | upper | replace "-" "_" }}_TOKEN
             valueFrom:
               secretKeyRef: {{ toYaml .Values.docBuilder.tokenSecretRef | nindent 16 }}
           {{- end }}

--- a/charts/kellnr/templates/doc-config.yaml
+++ b/charts/kellnr/templates/doc-config.yaml
@@ -22,5 +22,5 @@ data:
     [source.{{ .Values.docBuilder.registryName }}-local]
     registry = "sparse+http://localhost:{{ .Values.service.api.port }}/api/v1/crates/"
 
-    {{ .Values.docBuilder.configMapExtraConfig }}
+    {{ .Values.docBuilder.configMapExtraConfig | nindent 4 }}
 {{- end }}

--- a/charts/kellnr/templates/doc-config.yaml
+++ b/charts/kellnr/templates/doc-config.yaml
@@ -21,4 +21,6 @@ data:
 
     [source.{{ .Values.docBuilder.registryName }}-local]
     registry = "sparse+http://localhost:{{ .Values.service.api.port }}/api/v1/crates/"
+
+    {{ .Values.docBuilder.configMapExtraConfig }}
 {{- end }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -295,6 +295,8 @@ docBuilder:
   tokenSecretRef:
     name: kellnr-doc-token
     key: token
+  # Additional raw config appended to the generated Cargo config.toml.
+  configMapExtraConfig: ""
 
 dns:
   enabled: false


### PR DESCRIPTION
Two small changes, but I can split the PR if you prefer.

- env variables should be alphanumeric with underscores. We use crate registry name with a hyphen which creates a malformed env variable for the token and doc building dosn't work. Simple workaround is to use underscores in our name but that's not consistent how we use it elsewhere so this is a failsafe.
- we migrated from another registry and pushed all crates from there into kellnr. Now I would like kellnr to build the docs but while we've fixed the dependencies in json manifests, the raw content still points the dependencies to the old registry. We would like to add to the docs builder config.toml lines that would replace that registry with the local one (similarly to what kellner does to itself) but there is no way to extend that config toml right now.

The second change might be contentious and I am open to other possibilities. We could just add a token for now but we would also like to eventually sunset the old registry and not keep it around indefinitely for this. We could replace the contents of all the packages but if we don't have to, I'd rather not.