### PR TITLE
feat: allow secretRef for admin password, token, and s3 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ via `envFrom`:
 To add your own variables or mount additional ConfigMaps/Secrets, see
 [Extra environment variables](#extra-environment-variables).
 
+#### Admin password and token
+
+These credentials can also be set in any other secret and then referenced from this chart.
+
+| Setting                               | Required | Description                                                                                       | Default                            |
+|---------------------------------------|----------|---------------------------------------------------------------------------------------------------|------------------------------------|
+| kellnr.setup.adminPwd                 | No       | Inline password for the default admin account.                                                    | "admin"                            |
+| kellnr.setup.adminPwdSecretRef.name   | No       | Name of an existing Secret holding the password. Takes precedence over the inline value when set. | ""                                 |
+| kellnr.setup.adminPwdSecretRef.key    | No       | Key within that Secret.                                                                           | "adminPwd"                         |
+| kellnr.setup.adminToken               | No       | Inline read-write token for the default admin account.                                            | "Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD" |
+| kellnr.setup.adminTokenSecretRef.name | No       | Name of an existing Secret holding the token. Takes precedence over the inline value when set.    | ""                                 |
+| kellnr.setup.adminTokenSecretRef.key  | No       | Key within that Secret.                                                                           | "adminToken"                       |
+
+Notes:
+
+- Both fields have non-empty defaults, so the admin account always has credentials.
+  Change them before exposing Kellnr.
+- Provide a value inline to have the chart store it in its Secret, or point the
+  matching `adminPwdSecretRef`/`adminTokenSecretRef` at a Secret you manage yourself.
+
 #### Cookie signing key
 
 Kellnr uses a cookie signing key to sign its session cookie. Setting it is recommended
@@ -295,6 +315,23 @@ A _PersistentVolumeClaim_ can be used by _Kellnr_ to hold all stored data.
 | pvc.storage          | No       | Size of the storage.                                             | 5Gi   |
 
 For a full set of possible variables see: [values.yaml](./charts/kellnr/values.yaml)
+
+### S3 storage
+
+When _Kellnr_ uses S3-compatible object storage (`kellnr.s3.enabled`), the access and
+secret keys are sensitive and stored in the chart-managed Secret. Each can be provided
+inline or sourced from an existing Secret you manage yourself.
+
+| Setting                           | Required | Description                                                                                         | Default     |
+|-----------------------------------|----------|-----------------------------------------------------------------------------------------------------|-------------|
+| kellnr.s3.accessKey               | No       | Inline S3 access key.                                                                               | ""          |
+| kellnr.s3.accessKeySecretRef.name | No       | Name of an existing Secret holding the access key. Takes precedence over the inline value when set. | ""          |
+| kellnr.s3.accessKeySecretRef.key  | No       | Key within that Secret.                                                                             | "accessKey" |
+| kellnr.s3.secretKey               | No       | Inline S3 secret key.                                                                               | ""          |
+| kellnr.s3.secretKeySecretRef.name | No       | Name of an existing Secret holding the secret key. Takes precedence over the inline value when set. | ""          |
+| kellnr.s3.secretKeySecretRef.key  | No       | Key within that Secret.                                                                             | "secretKey" |
+
+For the full set of S3 options see: [values.yaml](./charts/kellnr/values.yaml)
 
 ## Feedback
 

--- a/charts/kellnr/Chart.yaml
+++ b/charts/kellnr/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.3
+version: 6.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/kellnr/templates/_helpers.tpl
+++ b/charts/kellnr/templates/_helpers.tpl
@@ -275,20 +275,20 @@ so it is injected directly into the container via secretKeyRef instead.
 Note: We avoid using "{{- if" and "{{- end" inside to prevent stripping newlines between variables.
 */}}
 {{- define "kellnr.secretEnvVars" -}}
-{{ if not (eq .Values.kellnr.setup.adminPwd nil) }}
+{{ if and (not (eq .Values.kellnr.setup.adminPwd nil)) (not .Values.kellnr.setup.adminPwdSecretRef.name) }}
 KELLNR_SETUP__ADMIN_PWD: {{ .Values.kellnr.setup.adminPwd | quote }}
 {{ end }}
-{{ if not (eq .Values.kellnr.setup.adminToken nil) }}
+{{ if and (not (eq .Values.kellnr.setup.adminToken nil)) (not .Values.kellnr.setup.adminTokenSecretRef.name) }}
 KELLNR_SETUP__ADMIN_TOKEN: {{ .Values.kellnr.setup.adminToken | quote }}
 {{ end }}
 {{ $cookieKey := include "kellnr.cookieSigningKey" . }}
 {{ if and (ne $cookieKey "") (not .Values.kellnr.registry.cookieSigningKeySecretRef.name) }}
 KELLNR_REGISTRY__COOKIE_SIGNING_KEY: {{ $cookieKey | quote }}
 {{ end }}
-{{ if .Values.kellnr.s3.accessKey }}
+{{ if and .Values.kellnr.s3.accessKey (not .Values.kellnr.s3.accessKeySecretRef.name) }}
 KELLNR_S3__ACCESS_KEY: {{ .Values.kellnr.s3.accessKey | quote }}
 {{ end }}
-{{ if .Values.kellnr.s3.secretKey }}
+{{ if and .Values.kellnr.s3.secretKey (not .Values.kellnr.s3.secretKeySecretRef.name) }}
 KELLNR_S3__SECRET_KEY: {{ .Values.kellnr.s3.secretKey | quote }}
 {{ end }}
 {{ if and .Values.kellnr.oauth2.clientSecret (not .Values.kellnr.oauth2.clientSecretRef.name) }}

--- a/charts/kellnr/templates/deployment.yaml
+++ b/charts/kellnr/templates/deployment.yaml
@@ -100,6 +100,26 @@ spec:
             valueFrom:
               secretKeyRef: {{ toYaml .Values.kellnr.registry.cookieSigningKeySecretRef | nindent 16 }}
           {{- end }}
+          {{- if .Values.kellnr.setup.adminPwdSecretRef.name }}
+          - name: KELLNR_SETUP__ADMIN_PWD
+            valueFrom:
+              secretKeyRef: {{ toYaml .Values.kellnr.setup.adminPwdSecretRef | nindent 16 }}
+          {{- end }}
+          {{- if .Values.kellnr.setup.adminTokenSecretRef.name }}
+          - name: KELLNR_SETUP__ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef: {{ toYaml .Values.kellnr.setup.adminTokenSecretRef | nindent 16 }}
+          {{- end }}
+          {{- if .Values.kellnr.s3.accessKeySecretRef.name }}
+          - name: KELLNR_S3__ACCESS_KEY
+            valueFrom:
+              secretKeyRef: {{ toYaml .Values.kellnr.s3.accessKeySecretRef | nindent 16 }}
+          {{- end }}
+          {{- if .Values.kellnr.s3.secretKeySecretRef.name }}
+          - name: KELLNR_S3__SECRET_KEY
+            valueFrom:
+              secretKeyRef: {{ toYaml .Values.kellnr.s3.secretKeySecretRef | nindent 16 }}
+          {{- end }}
           {{- if and .Values.docBuilder.enabled .Values.docBuilder.tokenSecretRef.name }}
           - name: RUSTUP_TOOLCHAIN
             value: {{ .Values.docBuilder.rustupToolchain | quote }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -110,7 +110,15 @@ extraEnvVarsSecret: ""
 kellnr:
   setup:
     adminPwd: "admin"
+    # When `name` is set, it takes precedence over the inline `adminPwd` above.
+    adminPwdSecretRef:
+      name: ""
+      key: "adminPwd"
     adminToken: "Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD"
+    # When `name` is set, it takes precedence over the inline `adminToken` above.
+    adminTokenSecretRef:
+      name: ""
+      key: "adminToken"
   registry:
     dataDir: "/var/lib/kellnr"
     sessionAgeSeconds: null # 28800
@@ -182,7 +190,15 @@ kellnr:
   s3:
     enabled: null # false
     accessKey: ""
+    # When `name` is set, it takes precedence over the inline `accessKey` above.
+    accessKeySecretRef:
+      name: ""
+      key: "accessKey"
     secretKey: ""
+    # When `name` is set, it takes precedence over the inline `secretKey` above.
+    secretKeySecretRef:
+      name: ""
+      key: "secretKey"
     region: ""
     endpoint: ""
     allowHttp: null # true


### PR DESCRIPTION
Right now we have to either have the secrets in plaintext in `values.yaml` or we have to use `extraEnvVars workaround like this:
```
extraEnvVars:
  - name: KELLNR_S3__SECRET_KEY
    valueFrom:
      secretKeyRef:
        ...
```

This allows to set the secretRef for admin password and token and for s3 credentials in the same way as can be done for oauth2 secret and cookie signing secret.