### PR TITLE
fix(doc-config): rename configMapExtraConfig to extraCargoConfig, guard empty value

### DIFF
--- a/charts/kellnr/Chart.yaml
+++ b/charts/kellnr/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.2
+version: 6.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/kellnr/templates/doc-config.yaml
+++ b/charts/kellnr/templates/doc-config.yaml
@@ -21,6 +21,8 @@ data:
 
     [source.{{ .Values.docBuilder.registryName }}-local]
     registry = "sparse+http://localhost:{{ .Values.service.api.port }}/api/v1/crates/"
+{{- with .Values.docBuilder.extraCargoConfig }}
 
-    {{ .Values.docBuilder.configMapExtraConfig | nindent 4 }}
+{{ . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/kellnr/values.yaml
+++ b/charts/kellnr/values.yaml
@@ -295,8 +295,8 @@ docBuilder:
   tokenSecretRef:
     name: kellnr-doc-token
     key: token
-  # Additional raw config appended to the generated Cargo config.toml.
-  configMapExtraConfig: ""
+  # Additional raw TOML appended to the generated Cargo config.toml.
+  extraCargoConfig: ""
 
 dns:
   enabled: false


### PR DESCRIPTION
## Summary

- Renames `docBuilder.configMapExtraConfig` to `docBuilder.extraCargoConfig` — the old name implied it configured the ConfigMap object itself, rather than appending content to the Cargo `config.toml` inside it
- Wraps the extra config block in `{{- with }}` so that an empty value produces no output (previously emitted a trailing whitespace-only line into the TOML)
- Switches from `nindent` to `indent` with an explicit blank line separator for clean single-blank-line spacing between sections

## Test plan

- [x] `helm template` with `docBuilder.extraCargoConfig` unset produces a clean `config.toml` with no trailing whitespace lines
- [x] `helm template` with `docBuilder.extraCargoConfig` set appends the extra TOML with a single blank line separator